### PR TITLE
feat(config): allow user to chose swagger path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,17 @@ custom:
     autoswagger:
         generateSwaggerOnDeploy?: true | false
         typefiles?: ['./src/types/typefile1.d.ts', './src/subfolder/helper.d.ts']
+        swaggerFiles?: ['./doc/endpointFromPlugin.json', './doc/iCannotPutThisInHttpEvent.json', './doc/aDefinitionWithoutTypescript.json']
+        swaggerPath?: 'string'
 ```
 
 `generateSwaggerOnDeploy` is a boolean which decides whether to generate a new swagger file on deployment. Default is `true`.
 
 `typefiles` is an array of strings which defines where to find the typescript types to use for the request and response bodies. Default is `./src/types/api-types.d.ts`.
+
+`swaggerFiles` is an array of string which will merge custom json OpenApi 2.0 files to the generated swagger
+
+`swaggerPath` is a string for customize swagger path. Default is `swagger`. Your new swagger UI will be available at `https://{your-url-domain}/{swaggerPath}`
 
 ## Adding more details
 

--- a/src/ServerlessAutoSwagger.ts
+++ b/src/ServerlessAutoSwagger.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { getTypeScriptReader, getOpenApiWriter, makeConverter, Writer, getOpenApiReader } from 'typeconv';
+import { getTypeScriptReader, getOpenApiWriter, makeConverter } from 'typeconv';
 import swaggerFunctions from './resources/functions';
 import * as fs from 'fs-extra';
 
@@ -14,7 +14,7 @@ import {
     FullHttpEvent,
     FullHttpApiEvent,
 } from './serverlessPlugin';
-import { Swagger, Definition, Paths, Response, PathMethods } from './swagger';
+import { Swagger, Definition, Response } from './swagger';
 import { removeStringFromArray, writeFile } from './helperFunctions';
 
 class ServerlessAutoSwagger {
@@ -38,6 +38,8 @@ class ServerlessAutoSwagger {
         this.serverless = serverless;
         this.options = options;
 
+        this.registerOptions();
+
         this.commands = {
             'generate-swagger': {
                 usage: 'Generates Swagger for your API',
@@ -51,6 +53,74 @@ class ServerlessAutoSwagger {
             'before:package:cleanup': this.predeploy,
         };
     }
+
+
+    registerOptions = () => {
+        this.serverless.configSchemaHandler.defineFunctionEventProperties('aws', 'http', {
+            properties: {
+                exclude: {
+                    type: 'boolean',
+                    nullable: true,
+                    defaultValue: false
+                },
+                swaggerTags: {
+                    type: 'array',
+                    nullable: true,
+                    items: {type: 'string'}
+                },
+                responses: {
+                    type: 'object',
+                    nullable: true,
+                    additionalProperties: {
+                        anyOf: [
+                            {
+                                type: 'string'
+                            },
+                            {
+                                type: 'object',
+                                required: [],
+                                properties: {
+                                    description: {
+                                        type: 'string'
+                                    },
+                                    bodyType: {
+                                        type: 'string'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                queryStringParameters: {
+                    type: 'object',
+                    nullable: true,
+                    required: [],
+                    additionalProperties: {
+                        type: 'object',
+                        required: ['required', 'type'],
+                        properties: {
+                            required: {
+                                type: 'boolean',
+                            },
+                            type: {
+                                type: 'string',
+                                enum: ['string', 'integer']
+                            },
+                            description: {
+                                type: 'string',
+                                nullable: true
+                            },
+                            minimum: {
+                                type: 'number',
+                                nullable: true
+                            }
+                        }
+                    }
+                }
+            },
+            required: [],
+        });
+    };
 
     predeploy = async () => {
         const generateSwaggerOnDeploy =
@@ -73,10 +143,10 @@ class ServerlessAutoSwagger {
         await Promise.all(swaggerFiles.map(async (filepath) => {
             const fileData = fs.readFileSync(filepath, 'utf8');
 
-            const jsonData = JSON.parse(fileData)
+            const jsonData = JSON.parse(fileData);
 
 
-            const { paths = {}, definitions = {}, ...swagger } = jsonData
+            const { paths = {}, definitions = {}, ...swagger } = jsonData;
 
 
             this.swagger = {
@@ -90,9 +160,9 @@ class ServerlessAutoSwagger {
                     ...this.swagger.definitions,
                     ...definitions,
                 }
-            }
-        }))
-    }
+            };
+        }));
+    };
 
     gatherTypes = async () => {
         // get the details from the package.json? for info
@@ -134,7 +204,7 @@ class ServerlessAutoSwagger {
                         this.swagger.definitions = {
                             ...this.swagger.definitions,
                             ...definitions,
-                        }
+                        };
                     } catch (error) {
                         console.log(`couldn't read types from file: ${filepath}`);
                         return;
@@ -167,7 +237,7 @@ module.exports = ${JSON.stringify(this.swagger, null, 2)};`;
     addEndpointsAndLambda = () => {
         this.serverless.service.functions = {
             ...this.serverless.service.functions,
-            ...swaggerFunctions,
+            ...swaggerFunctions(this.serverless),
         };
     };
 
@@ -178,7 +248,7 @@ module.exports = ${JSON.stringify(this.swagger, null, 2)};`;
             events
                 .filter(event => {
                     if (!((event as HttpEvent).http || (event as HttpApiEvent).httpApi)) {
-                        return false
+                        return false;
                     }
 
                     const http = (event as HttpEvent).http || (event as HttpApiEvent).httpApi;
@@ -187,7 +257,7 @@ module.exports = ${JSON.stringify(this.swagger, null, 2)};`;
                         return false;
                     }
 
-                    return !http.exclude
+                    return !http.exclude;
                 })
                 .map(event => {
                     let http = (event as HttpEvent).http || (event as HttpApiEvent).httpApi;
@@ -251,10 +321,6 @@ module.exports = ${JSON.stringify(this.swagger, null, 2)};`;
         // TODO - add security sections
         http.path;
         return undefined;
-    };
-
-    cleanDefinitions = (definitions: Record<string, Definition>) => {
-        Object.values(definitions).map(def => {});
     };
 
     httpEventToParameters = (httpEvent: EitherHttpEvent) => {

--- a/src/resources/functions.ts
+++ b/src/resources/functions.ts
@@ -1,17 +1,20 @@
-import { ServerlessFunction } from '../serverlessPlugin';
+import { ServerlessFunction, Serverless } from '../serverlessPlugin';
 
-export default (() => {
-    const path = 'swagger/';
-
+export default (serverless: Serverless) => {
+    const handlerPath = 'swagger/';
+    const path = serverless.service.custom?.autoswagger?.swaggerPath ?? 'swagger';
+    const name = serverless.configurationInput?.service?.name;
+    const stage = serverless.configurationInput?.provider?.stage;
     return {
         swaggerUI: {
-            handler: path + 'html.handler',
+            name: name && stage ? `${name}-${stage}-swaggerUI` : undefined,
+            handler: handlerPath + 'html.handler',
             disableLogs: true,
             events: [
                 {
                     http: {
                         method: 'get',
-                        path: 'swagger',
+                        path,
                         cors: true,
                     },
                 },
@@ -19,17 +22,18 @@ export default (() => {
         },
 
         swaggerJSON: {
-            handler: path + 'json.handler',
+            name: name && stage ? `${name}-${stage}-swaggerJSON` : undefined,
+            handler: handlerPath + 'json.handler',
             disableLogs: true,
             events: [
                 {
                     http: {
                         method: 'get',
-                        path: 'swagger.json',
+                        path: `${path}.json`,
                         cors: true,
                     },
                 },
             ],
         },
     } as Record<string, ServerlessFunction>;
-})();
+};

--- a/src/serverlessPlugin.d.ts
+++ b/src/serverlessPlugin.d.ts
@@ -3,6 +3,20 @@ export interface Serverless {
         log: Function;
     };
     service: ServerlessConfig;
+    configurationInput: {
+        service?: { name?: string },
+        provider?: {
+            stage?: string
+        }
+    },
+    configSchemaHandler: {
+        defineCustomProperties(schema: unknown): void;
+        defineFunctionEvent(provider: string, event: string, schema: Record<string, unknown>): void;
+        defineFunctionEventProperties(provider: string, existingEvent: string, schema: unknown): void;
+        defineFunctionProperties(provider: string, schema: unknown): void;
+        defineProvider(provider: string, options?: Record<string, unknown>): void;
+        defineTopLevelProperty(provider: string, schema: Record<string, unknown>): void;
+    };
 }
 
 export interface ServerlessConfig {


### PR DESCRIPTION
this PR provides:
- names for serverless-auto-swagger events
- some syntaxe warnings from my previous PR (;)
- option to customize the swagger path
- prevent warning from serverless :
```
functions.whatever.events[0].http': unrecognized property 'swaggerTags'
functions.whatever.events[0].http': unrecognized property 'responses'
functions.whatever.events[0].http': unrecognized property 'queryStringParameters'
```