### PR TITLE
feat: add basePath and schemes to custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ custom:
         swaggerPath?: 'string'
         apiKeyName?: 'string'
         useStage?: true | false
+        basePath?: '/string'
+        schemes?: ['http', 'https']
 ```
 
 `generateSwaggerOnDeploy` is a boolean which decides whether to generate a new swagger file on deployment. Default is `true`.
@@ -51,6 +53,10 @@ custom:
 `apiKeyName` is a string to define an API KEY. This is the name of your api key used on auth. For example, if you send it as a header named `x-api-key`, then the `apiKeyName` should be `x-api-key`
 
 `useStage` is a bool to either use current stage in beginning of path or not. The Default is `false`. For example, if you use it enabled (`true`) and your stage is `dev` the swagger will be in `dev/swagger`
+
+`basePath` is an optional string that can be prepended to every request (i.e. `http://localhost/basePath/my-endpoint`). Should include leading `/`.
+
+`schemes` is an optional array (containing one of `http`, `https`, `ws`, or `wss`) for specifying schemes. If not specified, uses the same scheme as the API specification (reflecting Swagger's behavior)
 
 ## Adding more details
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ custom:
         apiKeyName?: 'string'
         useStage?: true | false
         basePath?: '/string'
-        schemes?: ['http', 'https']
+        schemes?: ['http', 'https', 'ws', 'wss']
 ```
 
 `generateSwaggerOnDeploy` is a boolean which decides whether to generate a new swagger file on deployment. Default is `true`.

--- a/src/serverlessPlugin.d.ts
+++ b/src/serverlessPlugin.d.ts
@@ -8,7 +8,7 @@ export interface Serverless {
     provider?: {
       stage?: string
     }
-  }
+  },
   configSchemaHandler: {
     defineCustomProperties(schema: unknown): void
     defineFunctionEvent(
@@ -30,6 +30,9 @@ export interface Serverless {
   }
 }
 
+// ws and wss are WebSocket schemas
+type SwaggerScheme = 'http' | 'https' | 'ws' | 'wss'
+
 export interface AutoSwaggerCustomConfig {
   autoswagger?: {
     apiKeyName?: string
@@ -38,6 +41,8 @@ export interface AutoSwaggerCustomConfig {
     typefiles?: string[]
     useStage?: boolean
     swaggerPath?: string
+    basePath?: string
+    schemes?: SwaggerScheme[]
   }
 }
 

--- a/src/swagger.d.ts
+++ b/src/swagger.d.ts
@@ -4,7 +4,7 @@ export interface Swagger {
   host?: string
   basePath?: string
   tags?: Tag[]
-  schemes: string[]
+  schemes?: string[]
   paths: Paths
   securityDefinitions?: Record<string, SecurityDefinition>
   definitions?: Record<string, Definition>


### PR DESCRIPTION
- Added `basePath` optional attribute to custom config
- Added `schemes` optional attribute to custom config
- Removed default `schemes: ["https"]`, since Swagger allows undefined and defaults to the API Specification if left empty, which is a better way to default than assuming `https`.